### PR TITLE
adding notifications to disable the dismiss gesture

### DIFF
--- a/PopKit/Classes/PopKit.swift
+++ b/PopKit/Classes/PopKit.swift
@@ -71,11 +71,11 @@ extension PopKit {
         NotificationCenter.default.post(name: .dismissPopKit, object: nil)
     }
     
-    public static func menuStartedPresenting() {
+    public static func startedPresenting() {
         NotificationCenter.default.post(name: .startedPresenting, object: nil)
     }
     
-    public static func menuStoppedPresenting() {
+    public static func stoppedPresenting() {
         NotificationCenter.default.post(name: .stoppedPresenting, object: nil)
     }
 }

--- a/PopKit/Classes/PopKit.swift
+++ b/PopKit/Classes/PopKit.swift
@@ -57,12 +57,12 @@ extension Notification.Name {
         return Notification.Name("DismissPopKit")
     }
     
-    public static var menuStartedPresenting: NSNotification.Name {
-        return Notification.Name("MenuStartedPresenting")
+    public static var startedPresenting: NSNotification.Name {
+        return Notification.Name("PopKitStartedPresenting")
     }
     
-    public static var menuStoppedPresenting: NSNotification.Name {
-        return Notification.Name("MenuStoppedPresenting")
+    public static var stoppedPresenting: NSNotification.Name {
+        return Notification.Name("PopKitStoppedPresenting")
     }
 }
 
@@ -72,11 +72,11 @@ extension PopKit {
     }
     
     public static func menuStartedPresenting() {
-        NotificationCenter.default.post(name: .menuStartedPresenting, object: nil)
+        NotificationCenter.default.post(name: .startedPresenting, object: nil)
     }
     
     public static func menuStoppedPresenting() {
-        NotificationCenter.default.post(name: .menuStoppedPresenting, object: nil)
+        NotificationCenter.default.post(name: .stoppedPresenting, object: nil)
     }
 }
 

--- a/PopKit/Classes/PopKit.swift
+++ b/PopKit/Classes/PopKit.swift
@@ -56,11 +56,27 @@ extension Notification.Name {
     public static var dismissPopKit: NSNotification.Name {
         return Notification.Name("DismissPopKit")
     }
+    
+    public static var menuStartedPresenting: NSNotification.Name {
+        return Notification.Name("MenuStartedPresenting")
+    }
+    
+    public static var menuStoppedPresenting: NSNotification.Name {
+        return Notification.Name("MenuStoppedPresenting")
+    }
 }
 
 extension PopKit {
     public static func dismiss() {
         NotificationCenter.default.post(name: .dismissPopKit, object: nil)
+    }
+    
+    public static func menuStartedPresenting() {
+        NotificationCenter.default.post(name: .menuStartedPresenting, object: nil)
+    }
+    
+    public static func menuStoppedPresenting() {
+        NotificationCenter.default.post(name: .menuStoppedPresenting, object: nil)
     }
 }
 

--- a/PopKit/Classes/PopKitPresentationController.swift
+++ b/PopKit/Classes/PopKitPresentationController.swift
@@ -12,18 +12,18 @@ import UIKit
 class PopKitPresentationController: UIPresentationController {
     var popKit: PopKit?
     var effectView: UIView = UIView()
-    var menuIsPresenting = false
+    var isPresenting = false
     
     init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, popKit: PopKit?) {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         self.popKit = popKit
         
-        NotificationCenter.default.addObserver(forName: .menuStartedPresenting, object: nil, queue: .main) { [weak self] (notification) in
-            self?.menuIsPresenting = true
+        NotificationCenter.default.addObserver(forName: .startedPresenting, object: nil, queue: .main) { [weak self] (notification) in
+            self?.isPresenting = true
         }
         
-        NotificationCenter.default.addObserver(forName: .menuStoppedPresenting, object: nil, queue: .main) { [weak self] (notification) in
-            self?.menuIsPresenting = false
+        NotificationCenter.default.addObserver(forName: .stoppedPresenting, object: nil, queue: .main) { [weak self] (notification) in
+            self?.isPresenting = false
         }
         
         if let kit = popKit {
@@ -162,7 +162,7 @@ extension PopKitPresentationController: UIGestureRecognizerDelegate {
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         let point = touch.location(in: self.presentingViewController.view)
-        if !presentedViewController.view.frame.contains(point) && !menuIsPresenting {
+        if !presentedViewController.view.frame.contains(point) && !isPresenting {
             PopKit.dismiss()
         }
         return false

--- a/PopKit/Classes/PopKitPresentationController.swift
+++ b/PopKit/Classes/PopKitPresentationController.swift
@@ -12,10 +12,19 @@ import UIKit
 class PopKitPresentationController: UIPresentationController {
     var popKit: PopKit?
     var effectView: UIView = UIView()
+    var menuIsPresenting = false
     
     init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, popKit: PopKit?) {
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
         self.popKit = popKit
+        
+        NotificationCenter.default.addObserver(forName: .menuStartedPresenting, object: nil, queue: .main) { [weak self] (notification) in
+            self?.menuIsPresenting = true
+        }
+        
+        NotificationCenter.default.addObserver(forName: .menuStoppedPresenting, object: nil, queue: .main) { [weak self] (notification) in
+            self?.menuIsPresenting = false
+        }
         
         if let kit = popKit {
             
@@ -153,7 +162,7 @@ extension PopKitPresentationController: UIGestureRecognizerDelegate {
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         let point = touch.location(in: self.presentingViewController.view)
-        if !presentedViewController.view.frame.contains(point) {
+        if !presentedViewController.view.frame.contains(point) && !menuIsPresenting {
             PopKit.dismiss()
         }
         return false


### PR DESCRIPTION
Discovered that when presenting a viewcontroller from a hamburger menu item selection, the gesture recogniser fires for the PopKitPresentationController for the right side of the screen. 

In the PR is a possible solution to block the dismiss call by posting a notification once we have presented a controller and once we are done, which changes a bool to block the dismiss call in the gesture delegate method.